### PR TITLE
Use rattler build 0.39 (fix for macOS arm64)

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,3 +187,6 @@ Feedstock Maintainers
 
 * [@olivier-roussel](https://github.com/olivier-roussel/)
 
+
+<!-- dummy commit to enable rerendering -->
+

--- a/README.md
+++ b/README.md
@@ -187,6 +187,3 @@ Feedstock Maintainers
 
 * [@olivier-roussel](https://github.com/olivier-roussel/)
 
-
-<!-- dummy commit to enable rerendering -->
-

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,7 +1,7 @@
 context:
   name: nativefiledialog-extended
   version: 1.2.1
-  build_num: 1
+  build_num: 2
 
 package:
   name: ${{ name }}


### PR DESCRIPTION
Rebuild with rattler 0.39 as 0.38 causes problems on macOS arm64. See https://github.com/conda-forge/rattler-build-feedstock/issues/149

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

